### PR TITLE
ci: adjust dependabot schedule and add tailwindcss group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,17 @@ updates:
     open-pull-requests-limit: 20
     schedule:
       interval: "daily"
-      time: "07:30"
+      time: "05:00"
       timezone: "Asia/Tokyo"
+    groups:
+      tailwindcss:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
   - package-ecosystem: "github-actions"
     directory: "/"
     open-pull-requests-limit: 20
     schedule:
       interval: "daily"
-      time: "07:30"
+      time: "05:00"
       timezone: "Asia/Tokyo"


### PR DESCRIPTION
This pull request includes updates to the Dependabot configuration file `.github/dependabot.yml`. The most important changes focus on modifying the schedule time for updates and adding a new group for Tailwind CSS dependencies.

Scheduling updates:

* Changed the update schedule time from "07:30" to "05:00" for both the `updates:` and `github-actions` package ecosystems.

Grouping dependencies:

* Added a new group for Tailwind CSS dependencies, including patterns for `tailwindcss` and `@tailwindcss/*`.