### PR TITLE
RecentTopicsコンポーネントの実装とスタイル調整

### DIFF
--- a/src/app/components/RecentTopics.tsx
+++ b/src/app/components/RecentTopics.tsx
@@ -1,21 +1,23 @@
-import { getTopics } from '../../lib/getTopics';
+import { getTopics } from '@/lib/getTopics'
 
 export default function RecentTopics() {
-  const topics: string[] = getTopics();
+  const topics: string[] = getTopics()
 
   return (
     <section className="pt-10 pb-10">
-      <h2 className="text-iwdd border-t border-t-gray-200 py-10">最近話題に出たキーワード</h2>
+      <h2 className="text-iwdd border-t border-t-gray-200 py-10">
+        最近話題に出たキーワード
+      </h2>
       <div className="flex flex-wrap gap-2">
         {topics.map((topic, index) => (
           <span
             key={index}
-            className="bg-gray-200 text-gray-800 px-2 py-1 rounded-full text-xs font-medium hover:bg-gray-300"
+            className="rounded-full bg-gray-200 px-2 py-1 text-xs font-medium text-gray-800 hover:bg-gray-300"
           >
             {topic}
           </span>
         ))}
       </div>
     </section>
-  );
+  )
 }

--- a/src/app/components/RecentTopics.tsx
+++ b/src/app/components/RecentTopics.tsx
@@ -1,0 +1,21 @@
+import { getTopics } from '../../lib/getTopics';
+
+export default function RecentTopics() {
+  const topics: string[] = getTopics();
+
+  return (
+    <section className="pt-10 pb-10">
+      <h2 className="text-iwdd border-t border-t-gray-200 py-10">最近話題に出たキーワード</h2>
+      <div className="flex flex-wrap gap-2">
+        {topics.map((topic, index) => (
+          <span
+            key={index}
+            className="bg-gray-200 text-gray-800 px-2 py-1 rounded-full text-xs font-medium hover:bg-gray-300"
+          >
+            {topic}
+          </span>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,8 @@ import { formatPrice } from '@/lib/formatPrice'
 import { getHomeParams } from '@/lib/getHomeParams'
 import { getNextEvent } from '@/lib/getNextEvent'
 import { type HomeParams } from '@/types/HomeParams'
+import { getTopics } from '../lib/getTopics';
+import RecentTopics from './components/RecentTopics';
 
 export const metadata: Metadata = {
   title: 'IWDDはWebデザインとWeb開発のローカルコミュニティー',
@@ -66,6 +68,7 @@ const Home = async () => {
           </Link>
         </dd>
       </dl>
+      <RecentTopics />
     </main>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,12 @@
 import { type Metadata } from 'next'
 import Link from 'next/link'
 
+import RecentTopics from '@/app/components/RecentTopics'
 import { formatPrice } from '@/lib/formatPrice'
 import { getHomeParams } from '@/lib/getHomeParams'
 import { getNextEvent } from '@/lib/getNextEvent'
+import { getTopics } from '@/lib/getTopics'
 import { type HomeParams } from '@/types/HomeParams'
-import { getTopics } from '../lib/getTopics';
-import RecentTopics from './components/RecentTopics';
 
 export const metadata: Metadata = {
   title: 'IWDDはWebデザインとWeb開発のローカルコミュニティー',

--- a/src/lib/getTopics.ts
+++ b/src/lib/getTopics.ts
@@ -11,11 +11,16 @@ type Data = {
 };
 
 export function getTopics(): string[] {
-  const filePath = path.join(process.cwd(), 'data.yml');
-  const fileContents = fs.readFileSync(filePath, 'utf8');
-  const data = yaml.load(fileContents) as Data;
+  try {
+    const filePath = path.join(process.cwd(), 'data.yml');
+    const fileContents = fs.readFileSync(filePath, 'utf8');
+    const data = yaml.load(fileContents) as Data;
 
-  return (data.events || [])
-    .flatMap(event => event.topics || [])
-    .filter((topic, index, self) => topic !== '募集中' && self.indexOf(topic) === index);
+    return (data.events || [])
+      .flatMap(event => event.topics || [])
+      .filter((topic, index, self) => topic !== '募集中' && self.indexOf(topic) === index);
+  } catch (error) {
+    console.error('Error reading or parsing data.yml:', error);
+    return [];
+  }
 }

--- a/src/lib/getTopics.ts
+++ b/src/lib/getTopics.ts
@@ -1,0 +1,21 @@
+import yaml from 'js-yaml';
+import fs from 'fs';
+import path from 'path';
+
+type Event = {
+  topics?: string[];
+};
+
+type Data = {
+  events?: Event[];
+};
+
+export function getTopics(): string[] {
+  const filePath = path.join(process.cwd(), 'data.yml');
+  const fileContents = fs.readFileSync(filePath, 'utf8');
+  const data = yaml.load(fileContents) as Data;
+
+  return (data.events || [])
+    .flatMap(event => event.topics || [])
+    .filter((topic, index, self) => topic !== '募集中' && self.indexOf(topic) === index);
+}

--- a/src/lib/getTopics.ts
+++ b/src/lib/getTopics.ts
@@ -1,26 +1,29 @@
-import yaml from 'js-yaml';
-import fs from 'fs';
-import path from 'path';
+import fs from 'fs'
+import yaml from 'js-yaml'
+import path from 'path'
 
 type Event = {
-  topics?: string[];
-};
+  topics?: string[]
+}
 
 type Data = {
-  events?: Event[];
-};
+  events?: Event[]
+}
 
 export function getTopics(): string[] {
   try {
-    const filePath = path.join(process.cwd(), 'data.yml');
-    const fileContents = fs.readFileSync(filePath, 'utf8');
-    const data = yaml.load(fileContents) as Data;
+    const filePath = path.join(process.cwd(), 'data.yml')
+    const fileContents = fs.readFileSync(filePath, 'utf8')
+    const data = yaml.load(fileContents) as Data
 
     return (data.events || [])
-      .flatMap(event => event.topics || [])
-      .filter((topic, index, self) => topic !== '募集中' && self.indexOf(topic) === index);
+      .flatMap((event) => event.topics || [])
+      .filter(
+        (topic, index, self) =>
+          topic !== '募集中' && self.indexOf(topic) === index,
+      )
   } catch (error) {
-    console.error('Error reading or parsing data.yml:', error);
-    return [];
+    console.error('Error reading or parsing data.yml:', error)
+    return []
   }
 }


### PR DESCRIPTION
This pull request introduces a new feature to display recent topics on the homepage by extracting topic data from a YAML file. The changes include the addition of a new component, modifications to the main page to incorporate this component, and a utility function to fetch the topics.

### New Feature: Display Recent Topics

* **Added `RecentTopics` component**: A new component `RecentTopics` was created to display a list of recent topics. It fetches topics using the `getTopics` function and renders them as styled elements.
* **Modified `page.tsx`**: The `RecentTopics` component was imported and included in the main page layout to display the recent topics section. [[1]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR8-R9) [[2]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR71)
* **Created `getTopics` utility function**: A new utility function `getTopics` was added to read and parse topics from a `data.yml` file. This function filters out duplicate topics and excludes the topic '募集中'.