### PR TITLE
start_at で並び替え

### DIFF
--- a/src/lib/getTopics.ts
+++ b/src/lib/getTopics.ts
@@ -4,6 +4,7 @@ import path from 'path'
 
 type Event = {
   topics?: string[]
+  start_at?: string
 }
 
 type Data = {
@@ -11,19 +12,19 @@ type Data = {
 }
 
 export function getTopics(): string[] {
-  try {
-    const filePath = path.join(process.cwd(), 'data.yml')
-    const fileContents = fs.readFileSync(filePath, 'utf8')
-    const data = yaml.load(fileContents) as Data
+  const filePath = path.join(process.cwd(), 'data.yml')
+  const fileContents = fs.readFileSync(filePath, 'utf8')
+  const data = yaml.load(fileContents) as Data
 
-    return (data.events || [])
-      .flatMap((event) => event.topics || [])
-      .filter(
-        (topic, index, self) =>
-          topic !== '募集中' && self.indexOf(topic) === index,
-      )
-  } catch (error) {
-    console.error('Error reading or parsing data.yml:', error)
-    return []
-  }
+  return (data.events || [])
+    .filter((event) => event.start_at) // Ensure events have a start date
+    .sort(
+      (a, b) =>
+        new Date(b.start_at!).getTime() - new Date(a.start_at!).getTime(),
+    ) // Sort by start date descending
+    .flatMap((event) => event.topics || [])
+    .filter(
+      (topic, index, self) =>
+        topic !== '募集中' && self.indexOf(topic) === index,
+    )
 }


### PR DESCRIPTION
This pull request includes changes to the `src/lib/getTopics.ts` file to improve the processing of event data by ensuring events have a start date and sorting them by start date in descending order.

Improvements to event data processing:

* Modified the `getTopics` function to filter out events without a `start_at` date and sort the remaining events by their `start_at` date in descending order.