### PR TITLE
add iwdd-218 topics

### DIFF
--- a/src/data.json
+++ b/src/data.json
@@ -257,7 +257,12 @@
         "iwdd"
       ],
       "topics": [
-        "募集中"
+        "Windows 10 EOL",
+        "Office 365 賢い方",
+        "Microsoft Authorized Refurbisher",
+        "LM Studio",
+        "VS CodeのGithub Copilot agentsでtopics一覧表示を実装",
+        "IntelliJ IDEA AI AssistantのClaude 3.7 sonnetで実装を検証 "
       ]
     },
     {


### PR DESCRIPTION
This pull request updates the `src/data.json` file to include new topics related to various Microsoft products and AI tools.

* Updated the `topics` section to include:
  * "Windows 10 EOL"
  * "Office 365 賢い方"
  * "Microsoft Authorized Refurbisher"
  * "LM Studio"
  * "VS CodeのGithub Copilot agentsでtopics一覧表示を実装"
  * "IntelliJ IDEA AI AssistantのClaude 3.7 sonnetで実装を検証"