### PR TITLE
style: adjust alignment of topic keywords section

### DIFF
--- a/src/app/components/RecentTopics.tsx
+++ b/src/app/components/RecentTopics.tsx
@@ -10,7 +10,7 @@ export default async function RecentTopics() {
       <h2 className="border-t border-t-gray-200 py-10 text-iwdd">
         最近話題に出たキーワード
       </h2>
-      <div className="flex flex-wrap gap-2">
+      <div className="flex flex-wrap justify-center gap-2">
         {topics.map((topic, index) => (
           <span
             key={index}


### PR DESCRIPTION
This pull request includes a small but important change to the `RecentTopics` component in the `src/app/components/RecentTopics.tsx` file. The change ensures that the topics are centered within their container.

* [`src/app/components/RecentTopics.tsx`](diffhunk://#diff-14970691dbdaaeaf8ad3af6ef90caa163b8494d2312ed27818c10b78d85d3817L13-R13): Modified the `div` element's className to include `justify-center` for centering the topics.