### PR TITLE
chore: GitHub ActionsをSHA pinに変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,13 @@ jobs:
         runner: [ubuntu-latest]
         node: [24]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node }}
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
       - name: Lint
@@ -39,13 +39,13 @@ jobs:
         runner: [ubuntu-latest]
         node: [24]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
       - name: Install Playwright Browsers
@@ -53,7 +53,7 @@ jobs:
       - name: Run E2E Tests
         run: pnpm test:e2e
       - name: Upload Playwright Report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}
         with:
           name: playwright-report

--- a/renovate.json5
+++ b/renovate.json5
@@ -2,6 +2,7 @@
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: [
     'config:recommended',
+    'helpers:pinGitHubActionDigests',
     ':dependencyDashboard',
     ':semanticCommits',
     ':timezone(Asia/Tokyo)',


### PR DESCRIPTION
## 概要

サプライチェーン攻撃対策として、`.github/workflows/ci.yml` の全 GitHub Actions を full-length commit SHA に pin する。あわせて Renovate で未 pin アクションを自動的に SHA pin 化する設定を追加する。

## 関連Issue/PR

なし

## 変更内容

- `pinact` で `ci.yml` の全アクションを SHA pin に変換 (バージョンは `# vX.Y.Z` コメントで残す)
  - `actions/checkout@v6` → `de0fac2e...` (v6.0.2)
  - `actions/setup-node@v6` → `48b55a01...` (v6.4.0)
  - `pnpm/action-setup@v6` → `0e279bb9...` (v6.0.8)
  - `actions/upload-artifact@v7` → `043fb46d...` (v7.0.1)
- `renovate.json5` の `extends` に `helpers:pinGitHubActionDigests` を追加し、今後タグ参照で追加したアクションを Renovate が自動で SHA pin に変換する PR を出すようにした

## レビュー観点

- SHA pin 後も Renovate (`config:recommended` 内の `github-actions` manager) が `# vX.Y.Z` コメントを参照して通常の追従更新 PR を作成する想定です。動作監視よろしくお願いします
- `helpers:pinGitHubActionDigests` は `config:recommended` には含まれないため明示的に追加しました (`config:best-practices` には含まれます)
- `pinact` を CI で `--check` するチェックは入れていません。手動 + Renovate の保険で運用する想定です

## 破壊的変更

なし

## テスト計画

- [ ] PR の CI ジョブ (ci / e2e) が緑になることを確認
- [ ] マージ後の Renovate dependency dashboard で、新規に pinning PR が発生しないことを確認 (既に全アクション pin 済みのため)