### PR TITLE
chore: Renovate を config:best-practices 化し依存更新ポリシーを標準化

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,8 +1,9 @@
 # Supply-chain security (pnpm v11+, 単位: 分)
-# 1440 = 24h は v11 のデフォルト。明示することで v12 以降のデフォルト変更に対する固定化を意図。
-# Renovate 側で minimumReleaseAge: '2 days' を設定しているため、
-# Renovate 経由の更新は確実にこの cutoff を超える。
-minimumReleaseAge: 1440
+# 2880 = 48h。pnpm v11 デフォルト (1440/24h) より厳しくした独自値で、
+# 手動 pnpm add や lockFileMaintenance / pin 経由で入る間接依存にも 48h の猶予を与える。
+# Renovate 側でも config:best-practices の security:minimumReleaseAgeNpm により
+# npm パッケージは公開 3 日待ちとなり、pnpm floor (2日) <= Renovate gate (3日) を維持する。
+minimumReleaseAge: 2880
 
 # Build script policy (pnpm v11+)
 # v10 の onlyBuiltDependencies は v11 で削除され、allowBuilds map に統合された。

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,21 +1,30 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: [
-    'config:recommended',
-    'helpers:pinGitHubActionDigests',
-    ':dependencyDashboard',
+    // 公式ベストプラクティス集。recommended + configMigration / pinDevDependencies /
+    // docker:pinDigests / pinGitHubActionDigests / security:minimumReleaseAgeNpm 等を内包。
+    'config:best-practices',
+    // 依存更新の commit を semantic (fix(deps) / chore(deps)) に強制する。
     ':semanticCommits',
+    // schedule などの時刻基準を Asia/Tokyo にする。
     ':timezone(Asia/Tokyo)',
   ],
-  schedule: ['before 6am'],
+  // 更新 PR を作成する時間帯。cron 5 フィールド(分は必ず `*`)。月・木の終日。
+  schedule: ['* * * * 1,4'],
+  // 同時にオープンする PR の上限。
   prConcurrentLimit: 20,
+  // 時間あたり PR 作成数の上限を撤廃し、ウィンドウ内で一気に作成する。
+  prHourlyLimit: 0,
+  // 全 PR に付与するラベル。
   labels: ['dependencies'],
-  // pnpm v11 の minimumReleaseAge (default 24h = 1440 分) を確実に上回るため
-  // Renovate 側で公開から 2 日経過したパッケージのみ PR 化する。
-  // (PR 作成時点で pnpm install が確実に通るようにするためのバッファ)
-  minimumReleaseAge: '2 days',
+  // OSV データベースで脆弱性を検出する。
+  osvVulnerabilityAlerts: true,
+  // 未解決の脆弱性をダッシュボードにサマリ表示する。
+  dependencyDashboardOSVVulnerabilitySummary: 'unresolved',
+  // 直接依存の更新がなくても lockfile 全体を定期リフレッシュし間接依存を更新する。
   lockFileMaintenance: {
     enabled: true,
-    schedule: ['before 5am on monday'],
+    // 実行する時間帯。月曜の終日。
+    schedule: ['* * * * 1'],
   },
 }


### PR DESCRIPTION
## 概要

Renovate 設定を共通の標準に揃える(複数リポ横展開)。config:best-practices ベース化・スケジュールの cron 化(週2回・月木)・サプライチェーン待機期間の統一。

## 関連Issue/PR

- なし

## 変更内容

### Renovate (renovate.json5)
- config:recommended → config:best-practices に切替
- schedule を cron 化し毎日 → 週2回(月・木 `* * * * 1,4`)に統一、lockFileMaintenance も cron 化(月曜)
- prConcurrentLimit: 20 / prHourlyLimit: 0 に統一
- osvVulnerabilityAlerts / dependencyDashboardOSVVulnerabilitySummary を追加
- 冗長な :dependencyDashboard / helpers:pinGitHubActionDigests を削除、手動 minimumReleaseAge を security:minimumReleaseAgeNpm(npm 3日)に一本化

### pnpm (pnpm-workspace.yaml)
- minimumReleaseAge を 1440(24h)→ 2880(48h)に強化(allowBuilds は保持)

## 破壊的変更

なし。初回 Renovate 実行で devDependencies の pin / config 移行 PR が出る想定。

## テスト計画

- [ ] Renovate Dependency Dashboard が正常生成されること(マージ後)
- [ ] 月・木の想定どおりに PR が作成されること(マージ後)



